### PR TITLE
GTK Dynamic support

### DIFF
--- a/FlatColor/gtk-2.0/gtkrc.base
+++ b/FlatColor/gtk-2.0/gtkrc.base
@@ -1,6 +1,6 @@
 #modded Numix gtkrc
 
-gtk-color-scheme = "bg_color:{color8}
+gtk-color-scheme = "bg_color:{color0}
 color0:{color0}
 color1:{color1}
 color2:{color2}
@@ -20,11 +20,11 @@ color15:{color15}
 text_color:{color15}
 selected_bg_color:{active}
 selected_fg_color:{color15}
-tooltip_bg_color:{color8}
+tooltip_bg_color:{color0}
 tooltip_fg_color:{color15}
-titlebar_bg_color:{color8}
+titlebar_bg_color:{color0}
 titlebar_fg_color:{color15}
-menu_bg_color:{color8}
+menu_bg_color:{color0}
 menu_fg_color:{color15}
 link_color:{active}"
 gtk-auto-mnemonics	= 1

--- a/FlatColor/gtk-3.0/gtk.css.base
+++ b/FlatColor/gtk-3.0/gtk.css.base
@@ -1,13 +1,13 @@
 
 /* Default color scheme */
-@define-color bg_color #181818;
-@define-color fg_color #fff;
-@define-color base_color #101010;
-@define-color text_color #fff;
+@define-color bg_color {color0};
+@define-color fg_color {color15};
+@define-color base_color {color1};
+@define-color text_color {color15};
 @define-color selected_bg_color {active};
-@define-color selected_fg_color #fff;
-@define-color tooltip_bg_color #202020;
-@define-color tooltip_fg_color #fff;
+@define-color selected_fg_color {color15};
+@define-color tooltip_bg_color {color0};
+@define-color tooltip_fg_color {color15};
 
 /* colormap actually used by the theme, to be overridden in other css files */
 @define-color theme_bg_color @bg_color;


### PR DESCRIPTION
The GTK files provided by WPGTK tend to clash quite often with the colors generated by the program.
After doing a lot of tweaking and testing, I've come up with two changes that seem to make it blend better with the overall theme.

The color variables in the GTK-3.0.base file are changed to be dynamic, which also allows it to work much more seamlessly with a light theme, and I've changed the GTK-2.base background colors from 8 to 0, which is more of a personal touch to bring it into alignment with the general GTK base theme.